### PR TITLE
Spelling correction

### DIFF
--- a/OnlineWizard/OnlineWizard/Views/Home/Wizard.cshtml
+++ b/OnlineWizard/OnlineWizard/Views/Home/Wizard.cshtml
@@ -16,7 +16,7 @@
 </style>
 
 <div class='card-panel waves-effect waves-dark yellow darken-4' style=' width: 100%; padding: 10px;'>
-    <span class="white-text">Work in progress, the wizard is not functional yet, sory</span>
+    <span class="white-text">Work in progress, the wizard is not functional yet, sorry</span>
 </div>
 
 <div class="row">


### PR DESCRIPTION
sory is replaced with sorry at the end of sentence 'Work in progress, the wizard is not functional yet, sory'
